### PR TITLE
fix(BULL-44449): fix ES module output

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-signer",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "This repository provides library to sign any arbitrary message with an Bullish R1 key and produce an Bullish signature",
   "type": "module",
   "main": "dist/index.cjs.js",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "es2023",
-    "module": "commonjs",
+    "module": "ESNext",
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,


### PR DESCRIPTION
Having tsconfig on commonjs was causing esbuild to produce crazy ES output that wasn't compatible with loaders that support ES.